### PR TITLE
Remove danger gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 
-GEMS = %w(fastlane fastlane_core deliver snapshot frameit pem sigh produce cert gym pilot credentials_manager spaceship scan supply watchbuild danger)
+GEMS = %w(fastlane fastlane_core deliver snapshot frameit pem sigh produce cert gym pilot credentials_manager spaceship scan supply watchbuild)
 RAILS = %w(boarding refresher enhancer)
 
 #####################################################


### PR DESCRIPTION
As #3 mentioned, the `danger` gem is not moved to `fastlane` repo yet. So I guess we could remove it out temporarily until the `danger` being moved.
